### PR TITLE
Replaced gulp-xml-editor by gulp-xml-transformer

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var git = require('gulp-git');
 var semver = require('semver');
 var tap = require("gulp-tap");
 var filter = require('gulp-filter');
-var xmleditor = require('gulp-xml-editor');
+var xmleditor = require('gulp-xml-transformer');
 
 module.exports = function(gulp, userConfig) {
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "gulp-filter": "4.0.0",
     "gulp-git": "1.11.3",
     "gulp-tap": "0.1.3",
-    "gulp-xml-editor": "2.2.1",
+    "gulp-xml-transformer": "1.2.0",
     "semver": "5.3.0"
   }
 }


### PR DESCRIPTION
Replaced gulp-xml-editor by gulp-xml-transformer because gulp-xml-editor is not longer maintained and cannot be used with node versions > node4-lts (https://github.com/morou/gulp-xml-editor/issues/14). node4-lts maintenance will end in April 2017.