### PR TITLE
fix(gulp-git): update gulp-git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "gulp-bump": "2.4.0",
     "gulp-conventional-changelog": "1.1.0",
     "gulp-filter": "4.0.0",
-    "gulp-git": "1.11.3",
+    "gulp-git": "2.7.0",
     "gulp-tap": "0.1.3",
     "gulp-xml-transformer": "1.2.0",
     "semver": "5.3.0"


### PR DESCRIPTION
The outdated gulp-git caused errors in new nodejs versions as it used a deprecated dependency.